### PR TITLE
Makes issue card title clickable

### DIFF
--- a/src/components/IssueCard/IssueCard.tsx
+++ b/src/components/IssueCard/IssueCard.tsx
@@ -19,11 +19,11 @@ export function IssueCard(props: IssueCardProps) {
         <div className="col-md-10">
           <div className="card-body p-4">
             <span className="card-title">
-              {props.issue.title}
+              <a href={props.issue.url} target="_blank" rel="noopener noreferrer">
+                {props.issue.title}
+              </a>
               <small className="text-muted mr-2 float-right">
-                <a href={props.issue.url} target="_blank" rel="noopener noreferrer">
-                  #{props.issue.number}
-                </a>
+                (#{props.issue.number})
               </small>
             </span>
 


### PR DESCRIPTION
#29 It is difficult to explain to the newcomer that he needs to click on the tiny number to see the issue details. A quick fix is to make the title clickable. 