### PR TITLE
Increase the issue per page limit to 100

### DIFF
--- a/src/services/IssueService.ts
+++ b/src/services/IssueService.ts
@@ -56,7 +56,7 @@ async function GetRepositoryIssues(
   repo: string,
   state: IssueState = IssueState.OPEN,
   labels: string = '',
-  limit: number = 25,
+  limit: number = 100,
   page: number = 1,
   sort: 'updated' | 'created' | 'comments' | undefined = 'updated',
   direction: 'asc' | 'desc' | undefined = 'desc'


### PR DESCRIPTION
Increase the issue per page limit to 100, since we have more than 25 issues for voting in the TEC Hatch Config proposals.
Resolves #36.