### PR TITLE
Add get token message

### DIFF
--- a/src/components/TokenInfo/TokenInfo.tsx
+++ b/src/components/TokenInfo/TokenInfo.tsx
@@ -154,12 +154,25 @@ export function TokenInfo() {
     }
   };
 
+  const renderTokenMessage = () => {
+    if(repoContext.settings?.getTokenMessage && repoContext.settings?.getTokenLink) {
+      return (
+        <>
+          {repoContext.settings?.getTokenMessage} <a href={repoContext.settings?.getTokenLink}>here.</a>
+        </>
+      );
+    }
+  }
+
   return (
     <div className="card">
       <div className="card-body">
         <h5 className="card-title">{renderTokenName()}</h5>
         <h6 className="card-subtitle my-1 text-muted">{renderTokenLink()}</h6>
         <p className="card-text text-truncate">{renderBalance()}</p>
+        {(repoContext.settings?.getTokenMessage && repoContext.settings?.getTokenLink) ? 
+        <p className="card-text text-truncate">{renderTokenMessage()}</p> :
+        null}
         <NetworkBadge chainId={chainId} networkName={GetNetworkName(chainId)} />
 
         <span role="button" className="card-link" data-toggle="modal" data-target={`#repo-config-info`}>

--- a/src/types/RepositorySettings.ts
+++ b/src/types/RepositorySettings.ts
@@ -16,4 +16,6 @@ export interface RepositorySettings {
   votingMethod?: VotingMethod;
   chainId?: number;
   imageUrl?: string;
+  getTokenMessage?: string;
+  getTokenLink?: string;
 }


### PR DESCRIPTION
This PR adds a message prompting the user to get the token used for voting.
<img width="423" alt="image" src="https://user-images.githubusercontent.com/18421017/174515311-734fb7c3-4e68-40d9-8cf2-2b0df6da1cc6.png">

With this change, the `tokenlog.json` accepts `getTokenMessage` and `getTokenLink` to define the message and the link to get the token. 